### PR TITLE
Set file.path as the error object's .fileName

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = function (name) {
 			file.contents = new Buffer(react.transform(file.contents.toString()));
 			file.path = gutil.replaceExtension(file.path, '.js');
 		} catch (err) {
+			err.fileName = file.path;
 			this.emit('error', new gutil.PluginError('gulp-react', err));
 		}
 


### PR DESCRIPTION
The default error message generated when there's a syntax error in a JSX file doesn't include the source file name, only the line number the error was found on.

Adding a filePath property to the error object exposes this information for use in error handlers, e.g.:

``` javascript
var plumber = require('gulp-plumber')
var react = require('gulp-react')

gulp.task('compile-jsx', function() {
  return gulp.src('./src/**/*.jsx')
    .pipe(plumber())
    .pipe(react())
    .on('error', function(e) {
      console.error(e.message + '\n  in ' + e.fileName)
    })
    .pipe(gulp.dest('./build/modules'))
})
```
