### PR TITLE
Adding an option to addPragma, for the lazy developer

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,19 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var react = require('react-tools');
 
-module.exports = function (name) {
+module.exports = function (opts) {
+	if (!opts) opts = {};
+
+	var pragmaRegex = /^\s*\/\*\* @jsx React\.DOM \*\//i;
+	var pragma = '/** @jsx React.DOM */';
+	var defaults = {
+		addPragma: false
+	};
+
+	Object.keys(defaults).forEach(function(method) {
+		if (!opts[method]) opts[method] = defaults[method];
+	});
+
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			this.push(file);
@@ -16,7 +28,13 @@ module.exports = function (name) {
 		}
 
 		try {
-			file.contents = new Buffer(react.transform(file.contents.toString()));
+			var content = file.contents.toString();
+
+			if (opts.addPragma) {
+				if (!pragmaRegex.test(content)) content = pragma + content;
+			}
+
+			file.contents = new Buffer(react.transform(content));
 			file.path = gutil.replaceExtension(file.path, '.js');
 		} catch (err) {
 			err.fileName = file.path;

--- a/test.js
+++ b/test.js
@@ -2,9 +2,11 @@
 var assert = require('assert');
 var gutil = require('gulp-util');
 var react = require('./index');
+var fakeFile = 'var HelloMessage = React.createClass({render: function(){return <div>Hello {this.props.name}</div>;}});';
 
 it('should precompile React templates', function (cb) {
 	var stream = react();
+	var fakeFileWithPragma = '/** @jsx React.DOM */' + fakeFile;
 
 	stream.on('data', function (file) {
 		assert.equal(file.relative, 'fixture.js');
@@ -14,6 +16,20 @@ it('should precompile React templates', function (cb) {
 
 	stream.write(new gutil.File({
 		path: 'fixture.jsx',
-		contents: new Buffer('/** @jsx React.DOM */var HelloMessage = React.createClass({render: function(){return <div>Hello {this.props.name}</div>;}});')
+		contents: new Buffer(fakeFileWithPragma)
+	}));
+});
+
+it('should add pragma to React templates given addPragma option', function (cb) {
+	var stream = react({ addPragma: true });
+
+	stream.on('data', function (file) {
+		assert(/\/\*\* @jsx React\.DOM \*\//i.test(file.contents.toString()));
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'fixture.jsx',
+		contents: new Buffer(fakeFile)
 	}));
 });


### PR DESCRIPTION
This just adds in an option to insert a pragma at the top of a file automatically. After writing this out I realized react-tools may have this option built in already, but this is already written.

Anyway, is this useful for anyone else? I enjoyed the option on the react-brunch tool as all of my jsx files need the directive anyway.
