### PR TITLE
add support for harmony features of jsx

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var react = require('react-tools');
 
-module.exports = function (name) {
+module.exports = function (options) {
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
 			this.push(file);
@@ -23,7 +23,7 @@ module.exports = function (name) {
 		}
 
 		try {
-			file.contents = new Buffer(react.transform(str));
+			file.contents = new Buffer(react.transform(str, options));
 			file.path = gutil.replaceExtension(file.path, '.js');
 		} catch (err) {
 			err.fileName = file.path;

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,18 @@ gulp.task('default', function () {
 
 The JSX directive `/** @jsx React.DOM */` is automagically prepended to `.jsx` files if missing.
 
+## API
+
+### react(options)
+
+#### options
+
+##### harmony
+
+Type: `Boolean`
+Default: `false`
+
+Enable harmony options for jsx (full list of supported harmony features [here](https://github.com/facebook/jstransform/tree/master/visitors))
 
 ## License
 


### PR DESCRIPTION
This pull request adds support for the harmony features of react-tools.

I was a bit too early though as this is only enabled in master of react (see https://github.com/facebook/react/blob/master/main.js), so maybe this pull request can wait until 0.10 is released.

Note: You can use the harmony features already, because the harmony features are implemented in react 0.9. You only need the master of main.js
