### PR TITLE
Don't push file on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,9 @@ module.exports = function (options) {
 			file.path = gutil.replaceExtension(file.path, '.js');
 			this.push(file);
 		} catch (err) {
-			err.fileName = file.path;
-			this.emit('error', new gutil.PluginError('gulp-react', err));
+			this.emit('error', new gutil.PluginError('gulp-react', err, {
+				fileName: file.path
+			}));
 		}
 
 		cb();


### PR DESCRIPTION
Display the filename in the error (see https://github.com/gulpjs/gulp-util/issues/40). Additionally, only push files when they succeed. Before this change, the jsx file with a failed transform would be moved to output when an exception happened.
