### PR TITLE
Update React tools for 0.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-react",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Precompile Facebook React JSX templates into JavaScript",
   "license": "MIT",
   "repository": "sindresorhus/gulp-react",
@@ -34,7 +34,7 @@
   "dependencies": {
     "gulp-util": "^3.0.0",
     "react-dom-pragma": "^1.0.0",
-    "react-tools": "^0.11.2",
+    "react-tools": "^0.12.0",
     "through2": "^0.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Came out today, figured we should update.

Since there is a lot of backwards incompatibility, and most people pin like "~1.0.2", 1.1.0 would be necessary.
