### PR TITLE
Add keepExtension option

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,9 @@ module.exports = function (opts) {
 
 		try {
 			file.contents = new Buffer(react.transform(file.contents.toString(), opts));
-			file.path = gutil.replaceExtension(file.path, '.js');
+			if(!opts || (opts && !opts.keepExtension)) {
+				file.path = gutil.replaceExtension(file.path, '.js');
+			}
 			this.push(file);
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-react', err, {

--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,7 @@ gulp.task('default', function () {
 
 Options are passed to react-tools' [`transform` method](https://github.com/facebook/react/tree/master/npm-react-tools#transforminputstring-options).
 
+* `keepExtension [false]`. By default, `.jsx` files are renamed to `.js`. Set this option to true if you want to keep the original extension.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -32,3 +32,18 @@ it('should precompile React templates with --harmony flag', function (cb) {
 		contents: new Buffer('/** @jsx React.DOM */var HelloMessage = React.createClass({render: () => {return <div>Hello {this.props.name}</div>;}});')
 	}));
 });
+
+it('shouldn\'t touch extension if option is provided', function(cb) {
+	var stream = react({ keepExtension: true });
+
+	stream.on('data', function(file) {
+		assert.equal(file.relative, 'fixture.jsx');
+		assert(/"Hello "/.test(file.contents.toString()));
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		path: 'fixture.jsx',
+		contents: new Buffer('/** @jsx React.DOM */var HelloMessage = React.createClass({render: function(){return <div>Hello {this.props.name}</div>;}});')
+	}));
+});


### PR DESCRIPTION
I needed a way to keep the `.jsx` extension so I added the option `keepExtension`.
