### PR TITLE
Add support for sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,13 @@
   ],
   "dependencies": {
     "gulp-util": "^3.0.0",
-    "react-tools": "^0.12.0",
-    "through2": "^0.6.1"
+    "object-assign": "^2.0.0",
+    "react-tools": "^0.13.0-rc1",
+    "through2": "^0.6.1",
+    "vinyl-sourcemaps-apply": "^0.1.4"
   },
   "devDependencies": {
+    "gulp-sourcemaps": "^1.3.0",
     "mocha": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
 'use strict';
 var assert = require('assert');
 var gutil = require('gulp-util');
+var sourceMaps = require('gulp-sourcemaps');
 var react = require('./');
 
 it('should precompile React templates', function (cb) {
@@ -31,4 +32,31 @@ it('should precompile React templates with --harmony flag', function (cb) {
 		path: 'fixture.harmony.jsx',
 		contents: new Buffer('/** @jsx React.DOM */var HelloMessage = React.createClass({render: () => {return <div>Hello {this.props.name}</div>;}});')
 	}));
+});
+
+it('should generate source maps', function (cb) {
+	var init = sourceMaps.init();
+	var write = sourceMaps.write();
+
+	init
+		.pipe(react())
+		.pipe(write);
+
+	write.on('data', function (file) {
+		var contents = file.contents.toString();
+		assert.equal(file.sourceMap.sources[0], 'fixture.jsx');
+		assert(/React.createElement/.test(contents));
+		assert(/sourceMappingURL=data:application\/json;base64/.test(contents));
+		cb();
+	});
+
+	init.write(new gutil.File({
+		cwd: __dirname,
+		base: __dirname,
+		path: 'fixture.jsx',
+		contents: new Buffer('/** @jsx React.DOM */var HelloMessage = React.createClass({render: function(){return <div>Hello {this.props.name}</div>;}});'),
+		sourceMap: ''
+	}));
+
+	init.end();
 });


### PR DESCRIPTION
Had to use react-tools `0.13.0-rc1` since a [fix](https://github.com/facebook/react/pull/3164) for `sourceFilename` was landed recently.

Fixes #18.