### PR TITLE
Change reference from 'transform' to 'transformWithDetails'

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ gulp.task('default', function () {
 
 ### react(options)
 
-Options are passed to react-tools' [`transform` method](https://github.com/facebook/react/tree/master/npm-react-tools#transforminputstring-options).
+Options are passed to react-tools' [`transformWithDetails` method](https://github.com/facebook/react/tree/master/npm-react-tools#transformwithdetailsinputstring-options).
 
 
 ## Source Maps


### PR DESCRIPTION
'transformWithDetails' differs slightly from 'transform' for the sourceMap option. With 'transform', the expected behavior is that the sourcemap is appended inline to the output. 'transformWithDetails' returns the sourcemap in the result object. Please consider this change since the options doesn't behave as expected.

Alternatively, would it be a good idea to append the sourcemap to the output within gulp-react?
